### PR TITLE
Search Capitalization Bug

### DIFF
--- a/Sorting/ItemSorter.cs
+++ b/Sorting/ItemSorter.cs
@@ -138,7 +138,7 @@ namespace MagicStorage.Sorting
 			{
 				modName = item.modItem.mod.DisplayName;
 			}
-			return modName.ToLowerInvariant().IndexOf(modFilter) >= 0 && item.Name.ToLowerInvariant().IndexOf(filter) >= 0;
+			return modName.ToLowerInvariant().IndexOf(modFilter) >= 0 && item.Name.ToLowerInvariant().IndexOf(filter.ToLowerInvariant()) >= 0;
 		}
 	}
 }


### PR DESCRIPTION
When searching if you Typed "Bar" instead of "bar" the search would fail to return something.  This was due to the item name being lowercased for the search.

So lowercasing the filter text solves this.