### PR TITLE
Compress storage data during Netplay

### DIFF
--- a/Components/TEStorageUnit.cs
+++ b/Components/TEStorageUnit.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Threading;
 using Microsoft.Xna.Framework;
 using Terraria;
@@ -381,8 +382,15 @@ namespace MagicStorage.Components
 			}
 		}
 
-		public override void NetSend(BinaryWriter writer, bool lightSend)
+		public override void NetSend(BinaryWriter trueWriter, bool lightSend)
 		{
+			/* Recreate a BinaryWriter writer */
+			MemoryStream buffer = new MemoryStream(65536);
+			DeflateStream compressor = new DeflateStream(buffer, CompressionMode.Compress, true);
+			BufferedStream writerBuffer = new BufferedStream(compressor, 65536);
+			BinaryWriter writer = new BinaryWriter(writerBuffer);
+
+			/* Original code */
 			base.NetSend(writer, lightSend);
 			if (netQueue.Count > Capacity / 2 || !lightSend)
 			{
@@ -394,10 +402,44 @@ namespace MagicStorage.Components
 			{
 				netQueue.Dequeue().Send(writer, this);
 			}
+			
+			/* Forces data to be flushed into the compressed buffer */
+			writerBuffer.Flush(); compressor.Close();
+
+			/* Sends the buffer through the network */
+			trueWriter.Write((ushort)buffer.Length);
+			trueWriter.Write(buffer.ToArray());
+
+			/* Compression stats and debugging code (server side) */
+			if (false)
+			{
+				MemoryStream decompressedBuffer = new MemoryStream(65536);
+				DeflateStream decompressor = new DeflateStream(buffer, CompressionMode.Decompress, true);
+				decompressor.CopyTo(decompressedBuffer);
+				decompressor.Close(); 
+
+				Console.WriteLine("Magic Storage Data Compression Stats: " + decompressedBuffer.Length + " => " + buffer.Length);
+				decompressor.Dispose(); decompressedBuffer.Dispose();
+			}
+
+			/* Dispose all objects */
+			writer.Dispose(); writerBuffer.Dispose(); compressor.Dispose(); buffer.Dispose();
 		}
 
-		public override void NetReceive(BinaryReader reader, bool lightReceive)
+		public override void NetReceive(BinaryReader trueReader, bool lightReceive)
 		{
+			/* Reads the buffer off the network */
+			MemoryStream buffer = new MemoryStream(65536);
+			BinaryWriter bufferWriter = new BinaryWriter(buffer);
+
+			bufferWriter.Write(trueReader.ReadBytes(trueReader.ReadUInt16()));
+			buffer.Position = 0;
+
+			/* Recreate the BinaryReader reader */
+			DeflateStream decompressor = new DeflateStream(buffer, CompressionMode.Decompress, true);
+			BinaryReader reader = new BinaryReader(decompressor);
+
+			/* Original code */
 			base.NetReceive(reader, lightReceive);
 			if (TileEntity.ByPosition.ContainsKey(Position) && TileEntity.ByPosition[Position] is TEStorageUnit)
 			{
@@ -421,6 +463,9 @@ namespace MagicStorage.Components
 				RepairMetadata();
 			}
 			receiving = false;
+			
+			/* Dispose all objects */
+			reader.Dispose(); decompressor.Dispose(); bufferWriter.Dispose(); buffer.Dispose();
 		}
 
 		private void ClearItemsData()


### PR DESCRIPTION
Compresses Magic Storage data during multiplayer with an average compression ratio of 10:2, improving network performance and delaying #47 and #41 from occurring. Example of some storage units, all upgraded to Luminite, during a heavily modded run, are:

Magic Storage Data Compression Stats: 12014 => 2806
Magic Storage Data Compression Stats: 19412 => 3890
Magic Storage Data Compression Stats: 18932 => 3837
Magic Storage Data Compression Stats: 18476 => 3470
Magic Storage Data Compression Stats: 18896 => 3561

I left the compression stats code in but disabled. (See lines 413 - 423)