### PR TITLE
[1.4] Clear search text, aggregate items with same ItemData, fix placement bug

### DIFF
--- a/Components/StorageComponent.cs
+++ b/Components/StorageComponent.cs
@@ -20,8 +20,8 @@ namespace MagicStorage.Components
 		{
 			Main.tileSolidTop[Type] = true;
 			Main.tileFrameImportant[Type] = true;
+
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
-			TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.EmptyTile, TileObjectData.newTile.Width, 0);
 			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.HookCheckIfCanPlace = new PlacementHook(CanPlace, -1, 0, true);
 			ModifyObjectData();
@@ -30,7 +30,13 @@ namespace MagicStorage.Components
 				TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(tileEntity.Hook_AfterPlacement, -1, 0, false);
 			else
 				TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(TEStorageComponent.Hook_AfterPlacement_NoEntity, -1, 0, false);
+
+			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
+			TileObjectData.newAlternate.AnchorBottom = AnchorData.Empty;
+			TileObjectData.addAlternate(0);
+			
 			TileObjectData.addTile(Type);
+
 			ModTranslation text = CreateMapEntryName();
 			text.SetDefault("Magic Storage");
 			AddMapEntry(new Color(153, 107, 61), text);

--- a/Components/StorageComponent.cs
+++ b/Components/StorageComponent.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -19,14 +20,10 @@ namespace MagicStorage.Components
 		{
 			Main.tileSolidTop[Type] = true;
 			Main.tileFrameImportant[Type] = true;
-			TileObjectData.newTile.Width = 2;
-			TileObjectData.newTile.Height = 2;
-			TileObjectData.newTile.Origin = new Point16(1, 1);
-			TileObjectData.newTile.CoordinateHeights = new[] { 16, 16 };
-			TileObjectData.newTile.CoordinateWidth = 16;
-			TileObjectData.newTile.CoordinatePadding = 2;
+			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
+			TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.EmptyTile, TileObjectData.newTile.Width, 0);
+			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.HookCheckIfCanPlace = new PlacementHook(CanPlace, -1, 0, true);
-			TileObjectData.newTile.UsesCustomCanPlace = true;
 			ModifyObjectData();
 			ModTileEntity tileEntity = GetTileEntity();
 			if (tileEntity is not null)

--- a/Components/StorageConnector.cs
+++ b/Components/StorageConnector.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -13,14 +14,10 @@ namespace MagicStorage.Components
 		public override void SetStaticDefaults()
 		{
 			Main.tileSolid[Type] = false;
-			TileObjectData.newTile.Width = 1;
-			TileObjectData.newTile.Height = 1;
-			TileObjectData.newTile.Origin = new Point16(0, 0);
-			TileObjectData.newTile.CoordinateHeights = new[] { 16 };
-			TileObjectData.newTile.CoordinateWidth = 16;
-			TileObjectData.newTile.CoordinatePadding = 2;
+			TileObjectData.newTile.CopyFrom(TileObjectData.Style1x1);
+			TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.EmptyTile, TileObjectData.newTile.Width, 0);
+			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.HookCheckIfCanPlace = new PlacementHook(CanPlace, -1, 0, true);
-			TileObjectData.newTile.UsesCustomCanPlace = true;
 			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(Hook_AfterPlacement, -1, 0, false);
 			TileObjectData.addTile(Type);
 			ModTranslation text = CreateMapEntryName();

--- a/CraftingGUI.cs
+++ b/CraftingGUI.cs
@@ -53,7 +53,7 @@ namespace MagicStorage
 		private static UIElement topBar;
 
 		// TODO take a look at Terraria's UISearchBar
-		private static UI.UISearchBar searchBar;
+		public static UI.UISearchBar searchBar;
 		private static UIButtonChoice sortButtons;
 		internal static UIButtonChoice recipeButtons;
 		private static UIElement topBar2;

--- a/ItemData.cs
+++ b/ItemData.cs
@@ -1,8 +1,9 @@
+using System;
 using Terraria;
 
 namespace MagicStorage
 {
-	public struct ItemData
+	public struct ItemData : IComparable<ItemData>
 	{
 		public readonly int Type;
 		public readonly int Prefix;
@@ -13,31 +14,28 @@ namespace MagicStorage
 			Prefix = prefix;
 		}
 
-		public ItemData(Item item)
+		public ItemData(Item item) : this(item.type, item.prefix)
 		{
-			Type = item.type;
-			Prefix = item.prefix;
 		}
 
-		public override bool Equals(object other) => other is ItemData data && Matches(this, data);
+		public bool Equals(ItemData other) => Type == other.Type && Prefix == other.Prefix;
 
-		public override int GetHashCode() => 100 * Type + Prefix;
+		public override bool Equals(object obj) => obj is ItemData other && Equals(other);
 
-		public static bool Matches(Item item1, Item item2) => Matches(new ItemData(item1), new ItemData(item2));
+		public override int GetHashCode() => Type * 397 + Prefix;
 
-		public static bool Matches(ItemData data1, ItemData data2) => data1.Type == data2.Type && data1.Prefix == data2.Prefix;
+		public static bool operator ==(ItemData left, ItemData right) => left.Equals(right);
 
-		public static int Compare(Item item1, Item item2)
+		public static bool operator !=(ItemData left, ItemData right) => !left.Equals(right);
+
+		public static bool Matches(Item item1, Item item2) => new ItemData(item1) == new ItemData(item2);
+
+		public int CompareTo(ItemData other)
 		{
-			ItemData data1 = new(item1);
-			ItemData data2 = new(item2);
-			if (data1.Type != data2.Type)
-				return data1.Type - data2.Type;
-			return data1.Prefix - data2.Prefix;
+			int typeComparison = Type.CompareTo(other.Type);
+			if (typeComparison != 0)
+				return typeComparison;
+			return Prefix.CompareTo(other.Prefix);
 		}
-
-		public static bool operator ==(ItemData left, ItemData right) => Matches(left, right);
-
-		public static bool operator !=(ItemData left, ItemData right) => !(left == right);
 	}
 }

--- a/MagicStorageConfig.cs
+++ b/MagicStorageConfig.cs
@@ -30,6 +30,11 @@ namespace MagicStorage
 		[DefaultValue(false)]
 		public bool quickStackDepositMode;
 
+		[Label("Clear search text")]
+		[Tooltip("Enable to clear the search text when opening the UI")]
+		[DefaultValue(false)]
+		public bool clearSearchText;
+
 		public static MagicStorageConfig Instance => ModContent.GetInstance<MagicStorageConfig>();
 
 		[JsonIgnore]
@@ -43,6 +48,8 @@ namespace MagicStorage
 
 		[JsonIgnore]
 		public static bool QuickStackDepositMode => Instance.quickStackDepositMode;
+
+		[JsonIgnore] public static bool ClearSearchText => Instance.clearSearchText;
 
 		public override ConfigScope Mode => ConfigScope.ClientSide;
 	}

--- a/Sorting/ItemSorter.cs
+++ b/Sorting/ItemSorter.cs
@@ -15,8 +15,26 @@ namespace MagicStorage.Sorting
 			IEnumerable<Item> filteredItems = items.Where(item => filter.Passes(item) && FilterName(item, nameFilter) && FilterMod(item, modFilterIndex));
 			if (takeCount is not null)
 				filteredItems = filteredItems.Take(takeCount.Value);
+
+			filteredItems = Aggregate(filteredItems);
+
 			CompareFunction func = MakeSortFunction(sortMode);
 			return func is null ? filteredItems : filteredItems.OrderBy(x => x, func).ThenBy(x => x.type).ThenBy(x => x.value);
+		}
+
+		public static IEnumerable<Item> Aggregate(IEnumerable<Item> items)
+		{
+			var aggregateX = new Dictionary<ItemData, Item>();
+			foreach (Item item in items)
+			{
+				ItemData itemData = new ItemData(item);
+				if (aggregateX.TryGetValue(itemData, out Item i))
+					i.stack += item.stack;
+				else
+					aggregateX.Add(itemData, item.Clone());
+			}
+
+			return aggregateX.Values;
 		}
 
 		public static IEnumerable<Recipe> GetRecipes(SortMode sortMode, FilterMode filterMode, int modFilterIndex, string nameFilter)

--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -125,8 +125,18 @@ namespace MagicStorage
 			storageAccess = point;
 			remoteAccess = remote;
 			_latestAccessedStorage = GetStorageHeart();
+
 			if (MagicStorageConfig.UseConfigFilter && CraftingGUI.recipeButtons is not null)
+			{
 				CraftingGUI.recipeButtons.Choice = MagicStorageConfig.ShowAllRecipes ? 1 : 0;
+			}
+
+			if (MagicStorageConfig.ClearSearchText)
+			{
+				StorageGUI.searchBar?.Reset();
+				CraftingGUI.searchBar?.Reset();
+			}
+
 			StorageGUI.RefreshItems();
 		}
 

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = The Magic Storage Team
-version = 0.5.0.3
+version = 0.5.0.5
 displayName = Magic Storage
 homepage = https://github.com/blushiemagic/MagicStorage
 hideCode = false


### PR DESCRIPTION
Added config option for clearing search bar text when opening to UI

Made items with the same ItemData combine in UI
ItemData was slightly reworked to make it cleaner

Copy TileObjectData presets for consistency
Add Anchor to fix placement bug