### PR TITLE
Better Chinese inputting support for UISearchBar.

### DIFF
--- a/UISearchBar.cs
+++ b/UISearchBar.cs
@@ -9,6 +9,8 @@ using Terraria.Localization;
 using Terraria.GameInput;
 using Terraria.ModLoader;
 using Terraria.UI;
+using ReLogic.OS;
+using Terraria.UI.Chat;
 
 namespace MagicStorage
 {
@@ -181,10 +183,20 @@ namespace MagicStorage
                 color *= 0.75f;
             }
             spriteBatch.DrawString(font, drawText, new Vector2(dim.X + padding, dim.Y + padding), color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
-            if (!isEmpty && hasFocus && cursorTimer < 30)
+            if (!isEmpty && hasFocus)
             {
+                Main.instance.DrawWindowsIMEPanel(new Vector2(24f, 316f), 0f); // IME panel drawing. Necessary for inputting Chinese or some languages.
                 float drawCursor = font.MeasureString(drawText.Substring(0, cursorPosition)).X * scale;
-                spriteBatch.DrawString(font, "|", new Vector2(dim.X + padding + drawCursor, dim.Y + padding), color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
+                string compositionString = Platform.Current.Ime.CompositionString;
+                if (compositionString != null && compositionString.Length > 0) {
+                    Vector2 position = new Vector2(dim.X + padding + drawCursor, dim.Y + padding);
+                    ChatManager.DrawColorCodedStringShadow(spriteBatch, font, compositionString, position, color, 0f, Vector2.Zero, new Vector2(scale), spread: 1.2f); // an outline that makes composition string clearer
+                    spriteBatch.DrawString(font, compositionString, position, new Color(255, 240, 20), 0f, Vector2.Zero, scale, SpriteEffects.None, 0f); // composition string drawing
+                    drawCursor += font.MeasureString(compositionString).X * scale; // the cursor drawing position should be changed.
+                }
+                if (cursorTimer < 30) {
+                    spriteBatch.DrawString(font, "|", new Vector2(dim.X + padding + drawCursor, dim.Y + padding), color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
+                }
             }
         }
 

--- a/UISearchBar.cs
+++ b/UISearchBar.cs
@@ -185,7 +185,7 @@ namespace MagicStorage
             spriteBatch.DrawString(font, drawText, new Vector2(dim.X + padding, dim.Y + padding), color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
             if (!isEmpty && hasFocus)
             {
-                Main.instance.DrawWindowsIMEPanel(new Vector2(24f, 316f), 0f); // IME panel drawing. Necessary for inputting Chinese or some languages.
+                Main.instance.DrawWindowsIMEPanel(new Vector2(20f, Main.instance.invBottom + 60), 0f); // IME panel drawing. Necessary for inputting Chinese or some languages.
                 float drawCursor = font.MeasureString(drawText.Substring(0, cursorPosition)).X * scale;
                 string compositionString = Platform.Current.Ime.CompositionString;
                 if (compositionString != null && compositionString.Length > 0) {


### PR DESCRIPTION
I am Chinese and just started a modded playthrough with this mod. However, when I tried to search for items. I found that the IME panel doesn't show.
We Chinese use the Hanyu Pinyin Input Methods to type Chinese characters.
This is what should show if we tried to type in Terraria:
![image](https://user-images.githubusercontent.com/35227653/156823615-8a580ff5-30c0-409f-a92b-68558978d2c4.png)
If we want to type Chinese characters, we type Hanyu Pinyin and select the characters we want from the panel.
The input method panel and the yellow texts doesn't show in Magic Storage's searching bar rn. So I made this simple pr to make it show normally. It should be like this now:
![V6}@J3 B3NKQJ5TB@4``QI4](https://user-images.githubusercontent.com/35227653/156823482-51f15d69-746c-47a0-8c1d-aeab3d1f83c9.png)
This will be a useful improvement for us Chinese players.
