### PR TITLE
[1.4] Catch all items dropped during crafting

### DIFF
--- a/CraftingGUI.cs
+++ b/CraftingGUI.cs
@@ -122,8 +122,8 @@ namespace MagicStorage
 		private static FilterMode filterMode;
 
 		private static Dictionary<int, List<Recipe>> _productToRecipes;
-		public static bool compoundCrafting;
-		public static List<Item> compoundCraftSurplus = new();
+		public static bool CatchDroppedItems;
+		public static List<Item> DroppedItems = new();
 
 		private static bool[] adjTiles = new bool[TileLoader.TileCount];
 		private static bool adjWater;
@@ -1760,21 +1760,14 @@ namespace MagicStorage
 			resultItem.Prefix(-1);
 			var resultItems = new List<Item> { resultItem };
 
-			bool isCompound = RecursiveCraftIntegration.Enabled && RecursiveCraftIntegration.IsCompoundRecipe(selectedRecipe);
-			if (isCompound)
-			{
-				compoundCrafting = true;
-				compoundCraftSurplus.Clear();
-			}
+			CatchDroppedItems = true;
 
 			RecipeLoader.OnCraft(resultItem, selectedRecipe);
 			ItemLoader.OnCreate(resultItem, new RecipeCreationContext { recipe = selectedRecipe });
 
-			if (isCompound)
-			{
-				compoundCrafting = false;
-				resultItems.AddRange(compoundCraftSurplus);
-			}
+			CatchDroppedItems = false;
+			resultItems.AddRange(DroppedItems);
+			DroppedItems.Clear();
 
 			if (Main.netMode == NetmodeID.SinglePlayer)
 				foreach (Item item in DoCraft(GetHeart(), toWithdraw, resultItems))

--- a/Edits/CatchExtraCraftsDetour.cs
+++ b/Edits/CatchExtraCraftsDetour.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ModLoader;
+using OnPlayer = On.Terraria.Player;
+
+namespace MagicStorage.Edits;
+
+public class CatchExtraCraftsDetour : ILoadable
+{
+	public void Load(Mod mod)
+	{
+		OnPlayer.QuickSpawnItem_IEntitySource_int_int += OnPlayerQuickSpawnItem_IEntitySource_int_int;
+	}
+
+	public void Unload()
+	{
+		OnPlayer.QuickSpawnItem_IEntitySource_int_int -= OnPlayerQuickSpawnItem_IEntitySource_int_int;
+	}
+
+	private static int OnPlayerQuickSpawnItem_IEntitySource_int_int(OnPlayer.orig_QuickSpawnItem_IEntitySource_int_int orig,
+		Player self, IEntitySource source, int type, int stack)
+	{
+		if (!CraftingGUI.CatchDroppedItems)
+			return orig(self, source, type, stack);
+
+		Item item = new(type, stack);
+		CraftingGUI.DroppedItems.Add(item);
+		return -1; // return invalid value since this should never be used
+	}
+}

--- a/MagicStorage.cs
+++ b/MagicStorage.cs
@@ -328,23 +328,21 @@ namespace MagicStorage {
 
 		public override void PostAddRecipes() {
 			//Make a copy of every recipe that requires Ecto Mist, but let it be crafted at the appropriate combined station(s) as well
-			for (int i = 0; i < Recipe.maxRecipes; i++)
+			for (int i = 0; i < Recipe.numRecipes; i++)
 			{
 				Recipe recipe = Main.recipe[i];
 
+				if (recipe.Disabled)
+					continue;
+
 				if (recipe.HasCondition(Recipe.Condition.InGraveyardBiome))
 				{
-					Recipe copy = CreateRecipe(recipe.createItem.type, recipe.createItem.stack);
+					Recipe copy = CloneRecipe(recipe);
 
-					foreach (Item item in recipe.requiredItem)
-						copy.AddIngredient(item.type, item.stack);
+					copy.requiredTile.Clear();
+					copy.AddTile<CombinedStations4Tile>();
 
-					copy.acceptedGroups = new List<int>(recipe.acceptedGroups);
-
-					copy.requiredTile = new List<int>(recipe.requiredTile) { ModContent.TileType<CombinedStations4Tile>() };
-
-					//Copy all conditions except the graveyard one
-					copy.AddCondition(recipe.Conditions.Where(cond => cond != Recipe.Condition.InGraveyardBiome));
+					copy.RemoveCondition(Recipe.Condition.InGraveyardBiome);
 
 					copy.Register();
 				}

--- a/RecursiveCraftIntegration.cs
+++ b/RecursiveCraftIntegration.cs
@@ -5,9 +5,7 @@ using System.Runtime.CompilerServices;
 using MagicStorage.Components;
 using RecursiveCraft;
 using Terraria;
-using Terraria.DataStructures;
 using Terraria.ModLoader;
-using OnPlayer = On.Terraria.Player;
 
 namespace MagicStorage
 {
@@ -31,7 +29,6 @@ namespace MagicStorage
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		private static void StrongRef_Load()
 		{
-			OnPlayer.QuickSpawnItem_IEntitySource_int_int += OnPlayerQuickSpawnItem_IEntitySource_int_int;
 
 			Members.RecipeInfoCache = new();
 		}
@@ -66,24 +63,10 @@ namespace MagicStorage
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		private static void StrongRef_Unload()
 		{
-			OnPlayer.QuickSpawnItem_IEntitySource_int_int -= OnPlayerQuickSpawnItem_IEntitySource_int_int;
 
 			Members.RecipeInfoCache = null!;
 			Members.CompoundRecipes = null!;
 			Members.RecipeToCompoundRecipe = null!;
-		}
-
-		private static int OnPlayerQuickSpawnItem_IEntitySource_int_int(OnPlayer.orig_QuickSpawnItem_IEntitySource_int_int orig,
-			Player self, IEntitySource source, int type, int stack)
-		{
-			if (CraftingGUI.compoundCrafting)
-			{
-				Item item = new(type, stack);
-				CraftingGUI.compoundCraftSurplus.Add(item);
-				return -1; // return invalid value since this should never be used
-			}
-
-			return orig(self, source, type, stack);
 		}
 
 		private static Dictionary<int, int> FlatDict(IEnumerable<Item> items)


### PR DESCRIPTION
Makes it so we catch all items spawned/dropped during crafting instead of just the ones dropped by recursive recipes