### PR TITLE
Better Shadow Diamond Mod Support

### DIFF
--- a/Common/Systems/StorageWorld.cs
+++ b/Common/Systems/StorageWorld.cs
@@ -32,6 +32,7 @@ namespace MagicStorage.Common.Systems
 
 		//Modded support
 		public static HashSet<int> moddedDiamonds;
+		private static HashSet<string> unloadedModdedDiamonds;
 
 		internal static HashSet<int> disallowDropModded;
 		internal static Dictionary<int, Func<int>> moddedDiamondsDroppedByType;
@@ -64,6 +65,7 @@ namespace MagicStorage.Common.Systems
 			empressDiamond = false;
 
 			moddedDiamonds = new();
+			unloadedModdedDiamonds = new();
 		}
 
 		public override void PreSaveAndQuit() {
@@ -90,7 +92,7 @@ namespace MagicStorage.Common.Systems
 			tag["moonlordDiamond"] = moonlordDiamond;
 			tag["queenSlimeDiamond"] = queenSlimeDiamond;
 			tag["empressDiamond"] = empressDiamond;
-			tag["modded"] = moddedDiamonds.Select(i => ModContent.GetModNPC(i)).Where(m => m is not null).Select(m => $"{m.Mod.Name}:{m.Name}").ToList();
+			tag["modded"] = moddedDiamonds.Select(i => ModContent.GetModNPC(i)).Where(m => m is not null).Select(m => $"{m.Mod.Name}:{m.Name}").Concat(unloadedModdedDiamonds).ToList();
 
 			if (!Main.dedServ)
 				MagicStorageMod.Instance.optionsConfig.Save();
@@ -126,6 +128,8 @@ namespace MagicStorage.Common.Systems
 
 					if (ModLoader.TryGetMod(split[0], out Mod source) && source.TryFind(split[1], out ModNPC npc))
 						moddedDiamonds.Add(npc.Type);
+					else
+						unloadedModdedDiamonds.Add(identifier);
 				}
 			}
 		}

--- a/Items/ShadowDiamondDrop.cs
+++ b/Items/ShadowDiamondDrop.cs
@@ -175,7 +175,7 @@ namespace MagicStorage.Items
 				NPCID.HallowBoss        => !StorageWorld.empressDiamond,
 				_                       => false //Default to false to shove everything else under the rug
 			}
-			|| ShadowDiamondDrop.CanModdedNPCDrop(info.npc);
+			|| (ShadowDiamondDrop.CanModdedNPCDrop(info.npc) && !StorageWorld.moddedDiamonds.Contains(info.npc.type));
 
 		public bool CanShowItemDropInUI() => true; //Don't make the item show up in the bestiary
 

--- a/MagicStorageMod.cs
+++ b/MagicStorageMod.cs
@@ -144,7 +144,7 @@ namespace MagicStorage {
 					if (npcID < 0)
 						ThrowWithMessage("NPC ID must be positive", 1);
 					else if (npcID < NPCID.Count)
-						ThrowWithMessage("NPC ID must refer to a vanilla NPC ID", 1);
+						ThrowWithMessage("NPC ID must refer to a modded NPC ID", 1);
 
 					StorageWorld.moddedDiamondDropRulesByType.Add(npcID, rule);
 					break;


### PR DESCRIPTION
* Modded NPCs are now blocked from dropping Shadow Diamonds if they have dropped one in the past.
* Modded NPCs can no longer drop extra Shadow Diamonds by disabling and reenabling the mod the NPC is from.
* The `"Set Shadow Diamond Drop Rule"` call method now correctly tells users to use modded NPC types if a vanilla NPC type is provided.