### PR TITLE
fix invalid tooltips freezing client

### DIFF
--- a/Sorting/ItemSorter.cs
+++ b/Sorting/ItemSorter.cs
@@ -200,7 +200,14 @@ namespace MagicStorage.Sorting
 				//First character is a "#"?  Treat the search as a tooltip search
 				if (filter.Length > 1) {
 					filter = filter[1..];
-					return GetItemTooltipLines(item).Any(line => line.Contains(filter, StringComparison.OrdinalIgnoreCase));
+					try
+					{
+						return GetItemTooltipLines(item).Any(line => line.Contains(filter, StringComparison.OrdinalIgnoreCase));
+					}
+					catch
+					{
+						return false;
+					}
 				} else
 					return true;  //Empty tooltip = anything is valid
 			} else if (first == '@' && !modSearched) {


### PR DESCRIPTION
add a simple try catch
- should fix cases where the tooltip is not able to render - besides, what would there be to search for if the tooltip is simply broken?
- idea: add a way to search specifically for items that have broken tooltips - not technically necessary once this fix is in place, but could be nice to have