### PR TITLE
enhance performance: don't compress memorystreams before comparing

### DIFF
--- a/CrossMod/ItemCombining.cs
+++ b/CrossMod/ItemCombining.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Terraria;
 using Terraria.ModLoader;
 
@@ -15,7 +16,9 @@ namespace MagicStorage {
 
 		public abstract bool CanCombine(Item item1, Item item2);
 
-		public static bool CanCombineItems(Item item1, Item item2, bool checkPrefix = true) {
+		public static bool CanCombineItems(Item item1, Item item2, bool checkPrefix = true) => CanCombineItems(item1, item2, checkPrefix, null);
+
+		public static bool CanCombineItems(Item item1, Item item2, bool checkPrefix, ConditionalWeakTable<Item, byte[]> savedItemTagIO) {
 			int prefix1 = item1.prefix;
 			int prefix2 = item2.prefix;
 
@@ -49,7 +52,7 @@ namespace MagicStorage {
 
 			//Regardless of if the above allows combining, prevent items with different ModItemData from combining if they aren't the same
 			if (combine)
-				combine &= Utility.AreStrictlyEqual(item1, item2, checkPrefix: checkPrefix);
+				combine &= Utility.AreStrictlyEqual(item1, item2, checkStack: false, checkPrefix: checkPrefix, savedItemTagIO: savedItemTagIO);
 
 			item1.prefix = prefix1;
 			item2.prefix = prefix2;

--- a/Sorting/ItemSorter.cs
+++ b/Sorting/ItemSorter.cs
@@ -8,6 +8,7 @@ using Terraria.ModLoader;
 using Terraria.ID;
 using MagicStorage.CrossMod;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace MagicStorage.Sorting
 {
@@ -16,11 +17,13 @@ namespace MagicStorage.Sorting
 		public class AggregateContext {
 			public IEnumerable<Item> items;
 			public IEnumerable<List<Item>> sourceItems;
+			public ConditionalWeakTable<Item, byte[]> savedItemTagIO;
 			internal List<List<Item>> enumeratedSource;
 
 			public AggregateContext(IEnumerable<Item> items) {
 				this.items = items;
 				sourceItems = enumeratedSource = new();
+				savedItemTagIO = new();
 			}
 		}
 
@@ -107,7 +110,7 @@ namespace MagicStorage.Sorting
 						continue;
 					}
 
-					bool combiningPermitted = ItemCombining.CanCombineItems(item, lastItem);
+					bool combiningPermitted = ItemCombining.CanCombineItems(item, lastItem, checkPrefix: true, savedItemTagIO: context.savedItemTagIO);
 					if (combiningPermitted && (!actuallyAggregate || lastItem.stack + item.stack > 0))
 					{
 						if (actuallyAggregate)

--- a/StorageGUI.cs
+++ b/StorageGUI.cs
@@ -58,8 +58,6 @@ namespace MagicStorage
 
 		public static bool CurrentlyRefreshing { get; internal set; }
 
-		private static CancellationTokenSource threadSorting = new();
-
 		public static event Action OnRefresh;
 
 		internal static void CheckRefresh() {

--- a/Utility.cs
+++ b/Utility.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent;
@@ -67,7 +68,9 @@ namespace MagicStorage {
 			return count;
 		}
 
-		public static bool AreStrictlyEqual(Item item1, Item item2, bool checkStack = false, bool checkPrefix = true) {
+		public static bool AreStrictlyEqual(Item item1, Item item2, bool checkStack = false, bool checkPrefix = true) => AreStrictlyEqual(item1, item2, checkStack, checkPrefix, null);
+
+		public static bool AreStrictlyEqual(Item item1, Item item2, bool checkStack, bool checkPrefix, ConditionalWeakTable<Item, byte[]> savedItemTagIO) {
 			int stack1 = item1.stack;
 			int stack2 = item2.stack;
 			int prefix1 = item1.prefix;
@@ -96,7 +99,7 @@ namespace MagicStorage {
 			}
 
 			try {
-				equal = TagIOSave(item1).SequenceEqual(TagIOSave(item2));
+				equal = TagIOSave(item1, savedItemTagIO).SequenceEqual(TagIOSave(item2, savedItemTagIO));
 			} catch {
 				// Swallow the exception and disallow stacking
 				equal = false;
@@ -114,11 +117,17 @@ namespace MagicStorage {
 			return equal;
 		}
 
-		private static byte[] TagIOSave(Item item)
+		private static byte[] TagIOSave(Item item, ConditionalWeakTable<Item, byte[]> savedItemTagIO)
 		{
-			using MemoryStream memoryStream = new();
+			if (savedItemTagIO?.TryGetValue(item, out byte[] retVal) is true)
+			{
+				return retVal;
+			}
+			using MemoryStream memoryStream = new(200);
 			TagIO.ToStream(ItemIO.Save(item), memoryStream, false);
-			return memoryStream.ToArray();
+			retVal = memoryStream.ToArray();
+			savedItemTagIO?.Add(item, retVal);
+			return retVal;
 		}
 
 		public static void Write(this BinaryWriter writer, Point16 position) {

--- a/Utility.cs
+++ b/Utility.cs
@@ -114,9 +114,10 @@ namespace MagicStorage {
 			return equal;
 		}
 
-		private static byte[] TagIOSave(Item item) {
+		private static byte[] TagIOSave(Item item)
+		{
 			using MemoryStream memoryStream = new();
-			TagIO.ToStream(ItemIO.Save(item), memoryStream);
+			TagIO.ToStream(ItemIO.Save(item), memoryStream, false);
 			return memoryStream.ToArray();
 		}
 


### PR DESCRIPTION
should make the crafting and storage UI just a bit snappier.