### PR TITLE
Fix StorageConnector not dropping when broken

### DIFF
--- a/Components/StorageConnector.cs
+++ b/Components/StorageConnector.cs
@@ -28,11 +28,10 @@ namespace MagicStorage.Components
 			AddMapEntry(new Color(153, 107, 61), CreateMapEntryName());
 
 			DustType = 7;
-			
-			//--1.4.4 TESTING--//
-			//Check if actually needed
-			//ItemDrop/* tModPorter Note: Removed. Tiles and walls will drop the item which places them automatically. Use RegisterItemDrop to alter the automatic drop if necessary. */ = ModContent.ItemType<Items.StorageConnector>();
 
+			//RegisterItemDrop new to 1.4.4
+			RegisterItemDrop(ModContent.ItemType<Items.StorageConnector>());
+   
 			// Make the tile count as a door for housing purposes (like how platforms work)
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 		}


### PR DESCRIPTION
Updated the item drop type in StorageConnector class to meet 1.4.4 needs