### PR TITLE
Trigger a sound and a dust effect upon storage unit upgrade.

### DIFF
--- a/Components/StorageUnit.cs
+++ b/Components/StorageUnit.cs
@@ -2,6 +2,7 @@ using MagicStorage.Items;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.Localization;
@@ -145,6 +146,9 @@ namespace MagicStorage.Components
 					item.SetDefaults();
 				if (player.selectedItem == 58)
 					Main.mouseItem = item.Clone();
+
+				SoundEngine.PlaySound(SoundID.MaxMana, storageUnit.Position.ToWorldCoordinates());
+				Dust.NewDustPerfect(storageUnit.Position.ToWorldCoordinates(), DustID.PureSpray, Vector2.Zero, Scale: 2, newColor: Color.Green);
 
 				return true;
 			}


### PR DESCRIPTION
### Why?
To provide the player with a form of tactile feedback, ensuring utter satisfaction.

### Could it be implemented differently?
Could probably use more dust effect.