### PR TITLE
make ItemTypeOrderedSet save behavior more stable

### DIFF
--- a/ItemTypeOrderedSet.cs
+++ b/ItemTypeOrderedSet.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Terraria;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Config;
 using Terraria.ModLoader.IO;
 
 namespace MagicStorage
@@ -11,6 +12,7 @@ namespace MagicStorage
 		public static ItemTypeOrderedSet Empty => new("Empty");
 
 		private const string Suffix = "~v2";
+		private const string Suffix3 = "~v3";
 		private readonly string _name;
 		private List<Item> _items = new();
 		private HashSet<int> _set = new();
@@ -76,33 +78,36 @@ namespace MagicStorage
 
 		public void Save(TagCompound c)
 		{
-			c.Add(_name + Suffix, _items.Select(x => x.type).ToList());
+			c.Add(_name + Suffix3, _items.Select(x => new ItemDefinition(x.type)).ToList());
 		}
 
 		public void Load(TagCompound tag)
 		{
-			IList<TagCompound> list = tag.GetList<TagCompound>(_name);
-			if (list is not null && list.Count > 0)
+			if (tag.GetList<TagCompound>(_name) is { Count: > 0 } listV1) 
 			{
-				_items = list.Select(ItemIO.Load).ToList();
+				_items = listV1.Select(ItemIO.Load).ToList();
 			}
-			else
+			else if (tag.GetList<int>(_name + Suffix) is { Count: > 0 } listV2) 
 			{
-				IList<int> listV2 = tag.GetList<int>(_name + Suffix);
-				if (listV2 is not null)
-					_items = listV2.Select(x =>
-						{
-							if (x >= ItemLoader.ItemCount && ItemLoader.GetItem(x) == null)
-								return null;
-							Item item = new();
-							item.SetDefaults(x);
-							item.type = x;
-							return item;
-						})
-						.Where(x => x is not null)
-						.ToList();
-				else
-					_items = new List<Item>();
+				_items = listV2.Select(x =>
+				{
+					if (x >= ItemLoader.ItemCount && ItemLoader.GetItem(x) == null)
+						return null;
+					Item item = new();
+					item.SetDefaults(x);
+					item.type = x;
+					return item;
+				})
+				.Where(x => x is not null)
+				.ToList();
+			}
+			else if (tag.GetList<ItemDefinition>(_name + Suffix3) is { Count: > 0 } listV3) 
+			{
+				_items = listV3.Where(x => !x.IsUnloaded).Select(x => new Item(x.Type)).ToList();
+			} 
+			else 
+			{
+				_items = new List<Item>();
 			}
 
 			_set = new HashSet<int>(_items.Select(x => x.type));


### PR DESCRIPTION
Currently `ItemTypeOrderedSet` saves `Item.Type` directly. This results in erratic behavior when loaded mods change.
This PR uses `ItemDefinition` to save the list as a name reference to make the behavior more stable.