### PR TITLE
Change Automaton NPC from internal to public

### DIFF
--- a/NPCs/Golem.cs
+++ b/NPCs/Golem.cs
@@ -17,7 +17,7 @@ using Terraria.Utilities;
 
 namespace MagicStorage.NPCs {
 	[AutoloadHead]
-	internal class Golem : ModNPC {
+	public class Golem : ModNPC {
 		public bool newHelpTextAvailable;
 		public bool pendingNewHelpTextCheck;
 


### PR DESCRIPTION
The automaton npc should be public and not internal.

In my mod, I need to move the automaton away from the spawn point upon world creation. Right now, I can just hardcode the npc ID (688) to get the npc. For tiles in magic storage, weak references work perfectly well and are flexible in case of changes. However, because the automaton is internal I have to hardcode it's ID, which is prone to failure. 

To my knowledge, there's no real reason why this should be internal. Mods might want to access the NPC for a plethora of reasons, and I don't see why Magic Storage should impede them and force them to hardcode it's ID.