### PR TITLE
Add Hover Icon Indicator to Storage

### DIFF
--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -330,13 +330,38 @@ namespace MagicStorage
 
 		public override bool HoverSlot(Item[] inventory, int context, int slot)
 		{
-			if (storageAccess.X < 0 || storageAccess.Y < 0)
+			if (context != ItemSlot.Context.InventoryItem && context != ItemSlot.Context.InventoryCoin && context != ItemSlot.Context.InventoryAmmo)
 				return false;
-
+			if (storageAccess.X < 0 || storageAccess.Y < 0)
+				return base.HoverSlot(inventory, context, slot);
 			Item item = inventory[slot];
-
 			if (item.favorited || item.IsAir)
 				return false;
+
+			if (Player.inventory[slot] == inventory[slot])
+			{
+				bool pass = false;
+				using (SecuritySystem.CreateAccessContext())
+				{
+					foreach (TEAbstractStorageUnit storageUnit in GetStorageHeart().GetStorageUnits())
+					{
+						if (!storageUnit.IsFull || storageUnit.HasSpaceInStackFor(item))
+						{
+							pass = true;
+						}
+					}
+				}
+
+				if (pass == false)
+					return false;
+			}
+			else if (Player.inventory[slot] != inventory[slot])
+			{
+				if (!Player.CanAcceptItemIntoInventory(item))
+				{
+					return false;
+				}
+			}
 
 			if (ItemSlot.ShiftInUse)
 				Main.cursorOverride = 9;

--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -328,6 +328,22 @@ namespace MagicStorage
 			return true;
 		}
 
+		public override bool HoverSlot(Item[] inventory, int context, int slot)
+		{
+			if (storageAccess.X < 0 || storageAccess.Y < 0)
+				return false;
+
+			Item item = inventory[slot];
+
+			if (item.favorited || item.IsAir)
+				return false;
+
+			if (ItemSlot.ShiftInUse)
+				Main.cursorOverride = 9;
+
+			return base.HoverSlot(inventory, context, slot);
+		}
+
 		public TEStorageComponent GetStorageComponent() {
 			if (storageAccess.X < 0 || storageAccess.Y < 0)
 				return null;

--- a/StoragePlayer.cs
+++ b/StoragePlayer.cs
@@ -333,7 +333,7 @@ namespace MagicStorage
 			if (context != ItemSlot.Context.InventoryItem && context != ItemSlot.Context.InventoryCoin && context != ItemSlot.Context.InventoryAmmo)
 				return false;
 			if (storageAccess.X < 0 || storageAccess.Y < 0)
-				return base.HoverSlot(inventory, context, slot);
+				return false;
 			Item item = inventory[slot];
 			if (item.favorited || item.IsAir)
 				return false;
@@ -366,7 +366,7 @@ namespace MagicStorage
 			if (ItemSlot.ShiftInUse)
 				Main.cursorOverride = 9;
 
-			return base.HoverSlot(inventory, context, slot);
+			return false;
 		}
 
 		public TEStorageComponent GetStorageComponent() {


### PR DESCRIPTION
This change adds the little "chest insert" icon to Magic Storage items, to indicate whether or not item can be placed in the storage. Currently, there is no method to indicate this and the cursor does not change at all. This commit changes the cursor so that it displays the icon when shift-clicking the item would place the item in storage or take it out, and keeps it normal when shift-clicking would do nothing (no space in inventory, in storage, etc.)